### PR TITLE
updated dependencies to patch cargo audit vulnerabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ harness = false
 
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"]}
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ where
     type Timezone = T;
 
     fn now(&self) -> DateTime<Self::Timezone> {
-        Utc::now().with_timezone(&self)
+        Utc::now().with_timezone(self)
     }
 
     fn beginning_of_minute(&self) -> DateTime<Self::Timezone> {


### PR DESCRIPTION
Updated chrono's Cargo.toml entry to reflect solution listed in https://github.com/chronotope/chrono/issues/602#issuecomment-1242149249

Also updated criterion to latest version in order to silence `cargo audit` warnings.